### PR TITLE
Avoid a deprecation warning on RSpec 3.2

### DIFF
--- a/lib/govuk-content-schema-test-helpers/rspec_matchers.rb
+++ b/lib/govuk-content-schema-test-helpers/rspec_matchers.rb
@@ -12,10 +12,13 @@ module GovukContentSchemaTestHelpers
         "to be valid against '#{schema_name}' schema. Errors: #{validator.errors}"
       end
 
-      # Required for a helpful message with RSpec 2
-      failure_message_for_should do |actual|
-        validator = Validator.new(schema_name, actual)
-        "to be valid against '#{schema_name}' schema. Errors: #{validator.errors}"
+      if Gem.loaded_specs['rspec-expectations'].version < Gem::Version.new('3.0.0')
+        # Required for a helpful message with RSpec 2
+        # Generates a deprecation warning on 3.2.0
+        failure_message_for_should do |actual|
+          validator = Validator.new(schema_name, actual)
+          "to be valid against '#{schema_name}' schema. Errors: #{validator.errors}"
+        end
       end
     end
   end


### PR DESCRIPTION
RSpec::Matchers are part of the rspec-expectations gem, so I used that for
inspecting the version.

Tested successfully with policy-publisher (RSpec 3.2) and contacts-admin (RSpec 2.14).