### PR TITLE
Add the ability to fetch all examples for a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,42 @@ If you are not using Rails, you'll need to set `project_root` differently. Assum
   # => '{ "some": "json" }'
 ```
 
+#### Loading all examples for a given format
+
+
+```ruby
+  GovukContentSchemaTestHelpers::Examples.new.get_all_for_format('case_study')
+  # => ['{ "first": "example"}', '{ "second": "example" }']
+```
+
+This would be useful for checking your app can handle all examples and any that come into existence later:
+
+```ruby
+  def supported_formats
+    %w{
+      case_study
+      coming_soon
+    }
+  end
+
+  def all_examples_for_supported_formats
+    GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(supported_formats)
+  end
+
+  # In an ActionDispatch::IntegrationTest, for example:
+  test 'that we can handle every example of the formats we support'
+    all_examples_for_supported_formats.each do |example|
+      content_item = JSON.parse(example)
+      content_store_has_item(content_item['base_path'], content_item)
+
+      get content_item['base_path']
+      assert_response 200
+      assert_select 'title', content_item['title']
+    end
+  end
+```
+
+
 #### RSpec matcher
 
 To use the built-in RSpec matcher, add this to spec_helper.rb:

--- a/lib/govuk-content-schema-test-helpers/examples.rb
+++ b/lib/govuk-content-schema-test-helpers/examples.rb
@@ -10,6 +10,19 @@ module GovukContentSchemaTestHelpers
       File.read(path)
     end
 
+    def get_all_for_format(schema_name)
+      glob_path = example_path(schema_name, '*')
+      Dir.glob(glob_path).map do |path|
+        File.read(path)
+      end
+    end
+
+    def get_all_for_formats(schema_names)
+      schema_names.inject([]) do |memo, schema_name|
+        memo + get_all_for_format(schema_name)
+      end
+    end
+
     def check_example_file_exists!(path)
       if !File.exists?(path)
         raise ImproperlyConfiguredError, "Example file not found: #{path}."

--- a/lib/govuk-content-schema-test-helpers/examples.rb
+++ b/lib/govuk-content-schema-test-helpers/examples.rb
@@ -12,7 +12,7 @@ module GovukContentSchemaTestHelpers
 
     def check_example_file_exists!(path)
       if !File.exists?(path)
-        raise ImproperlyConfiguredError, "Schema file not found: #{path}."
+        raise ImproperlyConfiguredError, "Example file not found: #{path}."
       end
     end
 

--- a/lib/govuk-content-schema-test-helpers/examples.rb
+++ b/lib/govuk-content-schema-test-helpers/examples.rb
@@ -4,8 +4,8 @@ module GovukContentSchemaTestHelpers
       Util.check_govuk_content_schemas_path!
     end
 
-    def get(schema_name, example_name)
-      path = example_path(schema_name, example_name)
+    def get(format, example_name)
+      path = example_path(format, example_name)
       check_example_file_exists!(path)
       File.read(path)
     end
@@ -17,9 +17,9 @@ module GovukContentSchemaTestHelpers
     end
 
   private
-    def example_path(schema_name, example_name)
+    def example_path(format, example_name)
       schema_type = GovukContentSchemaTestHelpers.configuration.schema_type
-      File.join(Util.govuk_content_schemas_path, "/formats/#{schema_name}/#{schema_type}/examples/#{example_name}.json").to_s
+      File.join(Util.govuk_content_schemas_path, "/formats/#{format}/#{schema_type}/examples/#{example_name}.json").to_s
     end
   end
 end

--- a/spec/examples_spec.rb
+++ b/spec/examples_spec.rb
@@ -46,4 +46,47 @@ describe GovukContentSchemaTestHelpers::Examples do
       end
     end
   end
+
+  describe '#get_all_for_format' do
+    before do
+      GovukContentSchemaTestHelpers.configuration.project_root = File.join(File.dirname(__FILE__), '..')
+      GovukContentSchemaTestHelpers.configuration.schema_type = 'frontend'
+    end
+
+    after do
+      GovukContentSchemaTestHelpers.configuration.project_root = nil
+      GovukContentSchemaTestHelpers.configuration.schema_type = nil
+    end
+
+    it 'returns all examples for the format in an array' do
+      examples = subject.new.get_all_for_format('case_study')
+      expect(examples).to be_an(Array)
+      expect(examples.size).to be >= 2
+      examples.each do |example|
+        parsed_example = JSON.parse(example)
+        expect(parsed_example["format"]).to eql("case_study")
+      end
+    end
+  end
+
+  describe '#get_all_for_formats' do
+    before do
+      GovukContentSchemaTestHelpers.configuration.project_root = File.join(File.dirname(__FILE__), '..')
+      GovukContentSchemaTestHelpers.configuration.schema_type = 'frontend'
+    end
+
+    after do
+      GovukContentSchemaTestHelpers.configuration.project_root = nil
+      GovukContentSchemaTestHelpers.configuration.schema_type = nil
+    end
+
+    it 'returns all examples for the formats in an array' do
+      examples = subject.new.get_all_for_formats(['case_study', 'finder'])
+      expect(examples).to be_an(Array)
+      expect(examples.size).to be >= 2
+
+      formats_returned = examples.map { |e| JSON.parse(e)['format'] }.uniq
+      expect(formats_returned).to match_array(['case_study', 'finder'])
+    end
+  end
 end

--- a/spec/examples_spec.rb
+++ b/spec/examples_spec.rb
@@ -42,7 +42,7 @@ describe GovukContentSchemaTestHelpers::Examples do
 
     describe 'when the example does not exist' do
       it 'loads and parses the example file from govuk-content-schemas' do
-        expect { subject.new.get('made-up', 'or-a-typo') }.to raise_error(GovukContentSchemaTestHelpers::ImproperlyConfiguredError, /Schema file not found/)
+        expect { subject.new.get('made-up', 'or-a-typo') }.to raise_error(GovukContentSchemaTestHelpers::ImproperlyConfiguredError, /Example file not found/)
       end
     end
   end


### PR DESCRIPTION
government-frontend currently does this to test itself against all examples of
the formats it supports. We should do this in every frontend app, so let's make it easy.