### PR TITLE
Remove unnecessary cloning of govuk-content-schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ Then in a test:
 
 ### Running the test suite
 
-The tests in this project rely upon [govuk-content-schemas](http://github.com/alphagov/govuk-content-schemas) on your file system. By default these should be in a sibling directory to your project. Alternatively, you can specify their location with the `GOVUK_CONTENT_SCHEMAS_PATH` environment variable.
-
-Assuming you already have govuk-content-schemas cloned:
-
 ```
   bundle exec rake
 ```

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,11 +3,7 @@ set -e
 rm -f Gemfile.lock
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
-# Clone govuk-content-schemas depedency for contract tests
-rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
-
-GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
+bundle exec rake
 
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem


### PR DESCRIPTION
As of ebd6d0c370145eb1acd42ad1477f931c1368b994 the tests no longer depend on
govuk-content-schemas itself.