### PR TITLE
Don't specify date in gemspec

### DIFF
--- a/govuk-content-schema-test-helpers.gemspec
+++ b/govuk-content-schema-test-helpers.gemspec
@@ -7,7 +7,6 @@ require 'govuk-content-schema-test-helpers/version'
 Gem::Specification.new do |s|
   s.name        = 'govuk-content-schema-test-helpers'
   s.version     = GovukContentSchemaTestHelpers::VERSION
-  s.date        = '2015-03-10'
   s.summary     = "Test helpers for working with GOV.UK content schemas"
   s.description = "This app provides test helpers for working with [alphagov/govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas)"
   s.authors     = ["Jamie Cobbett", "David Heath"]


### PR DESCRIPTION
Specifying this date is causing rubygems.org to think that all our gem versions have been built on March 10, 2015.

![screen shot 2015-12-16 at 19 56 19](https://cloud.githubusercontent.com/assets/233676/11852322/2d40945c-a42f-11e5-9190-3c97c20b15f7.png)
https://rubygems.org/gems/govuk-content-schema-test-helpers