### PR TITLE
Use publisher_v2 schemas in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You will need to configure which type of schemas your app uses. A good place to 
   require 'govuk-content-schema-test-helpers'
 
   GovukContentSchemaTestHelpers.configure do |config|
-    config.schema_type = 'frontend' # or 'publisher'
+    config.schema_type = 'frontend' # or 'publisher_v2'
     config.project_root = Rails.root
   end
 ```


### PR DESCRIPTION
The `publisher` schemas are deprecated because the v1 API is deprecated. People
should be using the v2 schemas by default.