### PR TITLE
Raise an exception if no requested examples are found

### DIFF
--- a/lib/govuk-content-schema-test-helpers/examples.rb
+++ b/lib/govuk-content-schema-test-helpers/examples.rb
@@ -12,8 +12,14 @@ module GovukContentSchemaTestHelpers
 
     def get_all_for_format(schema_name)
       glob_path = example_path(schema_name, '*')
-      Dir.glob(glob_path).map do |path|
-        File.read(path)
+      example_paths = Dir.glob(glob_path)
+
+      if example_paths.any?
+        example_paths.map do |path|
+          File.read(path)
+        end
+      else
+        raise ImproperlyConfiguredError, "No examples found for schema: #{schema_name}"
       end
     end
 

--- a/spec/examples_spec.rb
+++ b/spec/examples_spec.rb
@@ -59,6 +59,11 @@ describe GovukContentSchemaTestHelpers::Examples do
           expect(parsed_example["format"]).to eql("minidisc")
         end
       end
+
+      it 'raises an exception if no examples are found for a requested formated' do
+        expect { subject.new.get_all_for_formats(['blah_format']) }.
+          to raise_error(GovukContentSchemaTestHelpers::ImproperlyConfiguredError, "No examples found for schema: blah_format")
+      end
     end
 
     describe '#get_all_for_formats' do


### PR DESCRIPTION
If we don't receive any examples for a schema then it gives us the illusion in our publishing/frontend test suites that something is being checked when it isn't. Better to fail hard and let us check if the schema itself exists or why there aren't any examples.

For example, the following code might be doing nothing.

```
examples = GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(["retired_schema_name", "schema_without_examples"])

examples.each do |example|
  get example['base_path']

  assert_response :success
end
```

This *will* cause test suites to fail which are trying to get examples that don't exist - but I think this is a good thing.