### PR TITLE
Update json-schema dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+Update json-schema dependency.
+
 ## 1.5.0
 
 * Allow looking up examples to work with schemas stored in

--- a/govuk-content-schema-test-helpers.gemspec
+++ b/govuk-content-schema-test-helpers.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/alphagov/govuk-content-schema-test-helpers'
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'json-schema', '~> 2.5.1'
+  s.add_runtime_dependency 'json-schema', '~> 2.8.0'
 
   s.add_development_dependency 'rake', '10.4.2'
   s.add_development_dependency 'rspec', '3.2.0'


### PR DESCRIPTION
This makes the dependency consistent with the govuk_schemas gem.